### PR TITLE
Fixed: fixed pkg errors

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"notifier/internal/pkg/watcher"
+	"doc-notifier/internal/pkg/watcher"
 )
 
 type Options struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,12 +9,6 @@ import (
 	"doc-notifier/internal/pkg/watcher"
 )
 
-type Options struct {
-	SearcherAddress  string
-	AssistantAddress string
-	WatchDirectories []string
-}
-
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "internal",
@@ -29,11 +23,13 @@ var rootCmd = &cobra.Command{
 		watcherPath, _ := cmd.Flags().GetStringArray("watcher-path")
 		fmt.Println(assistantAddr, searcherAddr, watcherPath)
 
-		watcher.New(&Options{
+		service := watcher.New(&watcher.Options{
 			SearcherAddress:  searcherAddr,
 			AssistantAddress: assistantAddr,
 			WatchDirectories: watcherPath,
 		})
+
+		service.RunWatcher()
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module notifier
+module doc-notifier
 
 go 1.21
 

--- a/internal/pkg/sender/sender.go
+++ b/internal/pkg/sender/sender.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"os"
 
-	"notifier/internal/pkg/reader"
+	"doc-notifier/internal/pkg/reader"
 )
 
 const SearcherURL = "/searcher/document/new"

--- a/internal/pkg/watcher/watcher.go
+++ b/internal/pkg/watcher/watcher.go
@@ -6,9 +6,8 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 
-	"notifier/cmd"
-	"notifier/internal/pkg/reader"
-	"notifier/internal/pkg/sender"
+	"doc-notifier/internal/pkg/reader"
+	"doc-notifier/internal/pkg/sender"
 )
 
 type NotifyWatcher struct {

--- a/internal/pkg/watcher/watcher.go
+++ b/internal/pkg/watcher/watcher.go
@@ -10,6 +10,12 @@ import (
 	"doc-notifier/internal/pkg/sender"
 )
 
+type Options struct {
+	SearcherAddress  string
+	AssistantAddress string
+	WatchDirectories []string
+}
+
 type NotifyWatcher struct {
 	directories []string
 	watcher     *fsnotify.Watcher
@@ -17,7 +23,7 @@ type NotifyWatcher struct {
 	reader      *reader.FileReader
 }
 
-func New(cmdOpts *cmd.Options) *NotifyWatcher {
+func New(cmdOpts *Options) *NotifyWatcher {
 	fileReader := reader.New()
 	fileSender := sender.New(cmdOpts.SearcherAddress, cmdOpts.AssistantAddress)
 	notifyWatcher, err := fsnotify.NewWatcher()

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"notifier/cmd"
+	"doc-notifier/cmd"
 )
 
 func main() {


### PR DESCRIPTION
There are following changes on `fix/fix-pkg-project` branch:
 - renamed project after creating repository with diff name;
 - moved Options struct to watcher.go pkg.